### PR TITLE
introduce common build_flags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,33 @@
 default_envs= 
     ttgo-sx1276-tbeam-v10
 
+[common]
+build_flags = -DWITH_ESP32
+              -DWITH_TBEAM       ; not sure about this flag?
+;              -DWITH_SPIFFS      ; use SPIFFS in flash
+;              -DWITH_SPIFFS_FAT  ; replace SPIFFS file system with FAT which seems not giving trouble when flash starts getting full
+;              -DWITH_LOG         ; log flights to flash
+;              -DWITH_FollowMe
+;              -DWITH_OLED
+;              -DWITH_U8G2_OLED
+              -DWITH_OGN
+              -DWITH_ADSL
+              -DWITH_PAW
+              -DWITH_FANET
+;              -DWITH_LORAWAN     ; compile error?
+              -DWITH_CONFIG      ; allow to change parameters via serial console
+              -DWITH_GPS_PPS     ; use the PPS of the GPS (not critical but gets betterr timing)
+              -DWITH_GPS_CONFIG  ; GPS can be adjusted for serial baud rate and navigation model
+              -DWITH_GPS_NMEA_PASS
+              -DWITH_BME280     ; recognizes automatically BMP280 or BME280
+              -DWITH_LOOKOUT
+              -DWITH_PFLAA
+              -DRADIOLIB_GODMODE ; advanced functions are needed from the RadioLib
+;              -DWITH_BT_SPP     ; BT4 serial port for XCsoar - but cannot work with AP
+              -DWITH_AP          ; WiFi Access Point
+;              -DWITH_AP_BUTTON   ; compile error?
+              -DWITH_HTTP
+
 [env]
 ; platform = https://github.com/platformio/platform-espressif32.git
 platform = espressif32
@@ -45,165 +72,65 @@ board_build.partitions = partitions.csv
 board_build.embed_files =
   src/OGN_logo_240x240.jpg
 
-[env:ttgo-sx1276-tbeam-07]
+[env:ttgo-sx1276-tbeam-07]     ; T-Beam v0.7
 board = ttgo-lora32-v1
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
-              -DWITH_OGN
+build_flags = ${common.build_flags}
               -DWITH_TBEAM07
               -DWITH_SX1276
-              -DWITH_CONFIG     ; allow to change parameters via serial console
+              -DWITH_AXP        ; AXP192 power chip
               -DWITH_GPS_UBX
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-;              -DWITH_BME280     ; recognizes automatically BMP280 or BME280
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
+              -DWITH_GPS_UBX_PASS
 
-
-[env:ttgo-sx1276-tbeam-v10]
+[env:ttgo-sx1276-tbeam-v10]     ; T-Beam v1.1
 board = ttgo-lora32-v1
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
-              -DWITH_SPIFFS     ; use SPIFFS in flash
-              -DWITH_SPIFFS_FAT ; replace SPIFFS file system with FAT which seems not giving trouble when flash starts getting full
-              -DWITH_LOG        ; log flights to flash
-              -DWITH_OGN
-              -DWITH_ADSL
-              -DWITH_PAW
-              -DWITH_FANET
+build_flags = ${common.build_flags}
               -DWITH_TBEAM10
               -DWITH_SX1276
-              -DWITH_AP         ; WiFi Access Point
-              -DWITH_HTTP
-;              -DWITH_BT_SPP     ; BT4 serial port for XCsoar - but cannot work with AP
-              -DWITH_CONFIG     ; allow to change parameters via serial console
+              -DWITH_AXP        ; AXP192 power chip
               -DWITH_GPS_UBX
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-              -DWITH_AXP
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
+              -DWITH_GPS_UBX_PASS
 
-
-[env:ttgo-sx1276-tbeam-v20]
+[env:ttgo-sx1262-tbeam-v10]     ; T-Beam v1.1
 board = ttgo-lora32-v1
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
-              -DWITH_OGN
-              -DWITH_ADSL
-              -DWITH_PAW
-              -DWITH_FANET
-              -DWITH_TBEAM20
-              -DWITH_SX1276     ; RF chip, some have SX1262
-              -DWITH_BT_SPP     ; BT Standard Serial Port => connection to XCsoar, takes big resources in Flash and RAM
-              -DWITH_CONFIG     ; allow to change parameters via serial console
-              -DWITH_GPS_UBX    ; uBlox GPS
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-              -DWITH_XPOWERS    ; AXP2101 power chip
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
-
-
-[env:ttgo-sx1262-tbeam-v10]
-board = ttgo-lora32-v1
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
-              -DWITH_SPIFFS     ; use SPIFFS in flash
-              -DWITH_SPIFFS_FAT ; replace SPIFFS file system with FAT which seems not giving trouble when flash starts getting full
-              -DWITH_LOG        ; log flights to flash
-              -DWITH_OGN
-              -DWITH_ADSL
-              -DWITH_PAW
-              -DWITH_FANET
+build_flags = ${common.build_flags}
               -DWITH_TBEAM10
               -DWITH_SX1262
-;              -DWITH_AP
-;              -DWITH_HTTP
-              -DWITH_BT_SPP     ; BT Standard Serial Port => connection to XCsoar, takes big resources in Flash and RAM
-              -DWITH_CONFIG     ; allow to change parameters via serial console
+              -DWITH_AXP        ; AXP192 power chip
               -DWITH_GPS_UBX
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-              -DWITH_AXP
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
+              -DWITH_GPS_UBX_PASS
 
+[env:ttgo-sx1276-tbeam-v20]     ; T-Beam v1.2
+board = ttgo-lora32-v1
+build_flags = ${common.build_flags}
+              -DWITH_TBEAM20
+              -DWITH_SX1276
+              -DWITH_XPOWERS    ; AXP2101 power chip
+              -DWITH_GPS_UBX
+              -DWITH_GPS_UBX_PASS
 
 [env:ttgo-sx1262-tbeam-s3-mtk]
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
+build_flags = ${common.build_flags}
               -DWITH_TBEAMS3
-              -DWITH_OGN
-              -DWITH_SD
-              -DWITH_OLED
-              -DWITH_ADSL
-              -DWITH_PAW
-              -DWITH_FANET
               -DWITH_SX1262
-              -DWITH_CONFIG     ; allow to change parameters via serial console
               -DWITH_GPS_MTK
-              -DWITH_GPS_ENABLE
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-;              -DWITH_BME280     ; recognizes automatically BMP280 or BME280
-              -DWITH_XPOWERS
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
-              -DARDUINO_USB_MODE=1           ; direct-USB mode: not an UART bridge
+              -DDWITH_GPS_ENABLE
+              -DWITH_XPOWERS    ; AXP2101 power chip
+              -DARDUINO_USB_MODE=1  ; direct-USB mode: not an UART bridge
               -DARDUINO_USB_CDC_ON_BOOT=1 
-
+;              -DWITH_SD
+;              -DWITH_SDLOG
 
 [env:ttgo-sx1262-tbeam-s3-ubx]
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
+build_flags = ${common.build_flags}
               -DWITH_TBEAMS3
-              -DWITH_OGN
-;              -DWITH_OLED
               -DWITH_SX1262
-              -DWITH_CONFIG     ; allow to change parameters via serial console
               -DWITH_GPS_UBX
-              -DWITH_GPS_ENABLE
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-;              -DWITH_BME280     ; recognizes automatically BMP280 or BME280
-              -DWITH_XPOWERS
-;              -DWITH_BT_SPP     ; BT Standard Serial Port => connection to XCsoar, takes big resources in Flash and RAM
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DARDUINO_USB_MODE=1           ; direct-USB mode: not an UART bridge
+              -DWITH_XPOWERS    ; AXP2101 power chip
+              -DARDUINO_USB_MODE=1  ; direct-USB mode: not an UART bridge
               -DARDUINO_USB_CDC_ON_BOOT=1 
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
-
-
-
-[env:ttgo-sx1276-tbeam-07-stratux]
-board = ttgo-lora32-v1
-build_flags = -DTTGO_TBEAM
-              -DWITH_ESP32
-              -DWITH_OGN
-              -DWITH_TBEAM07
-              -DWITH_SX1276
-              -DWITH_CONFIG     ; allow to change parameters via serial console
-              -DWITH_GPS_UBX
-              -DWITH_GPS_UBX_PASS
-              -DWITH_GPS_NMEA_PASS
-              -DWITH_GPS_PPS    ; use the PPS of the GPS (not critical but gets betterr timing)
-;              -DWITH_GPS_CONFIG ; GPS can be adjusted for serial baud rate and navigation model
-              -DWITH_BME280     ; recognizes automatically BMP280 or BME280
-;              -DWITH_BT_SPP     ; BT Standard Serial Port => connection to XCsoar, takes big resources in Flash and RAM
-              -DWITH_LOOKOUT
-              -DWITH_PFLAA
-              -DRADIOLIB_GODMODE             ; advanced functions are needed from the RadioLib
-
-
+;              -DWITH_SD
+;              -DWITH_SDLOG


### PR DESCRIPTION
This PR is mainly to simplify the build_flags arrangement, certainly needs to be double checked. One target "ttgo-sx1276-tbeam-07-stratux" has been removed.