### PR TITLE
VBACKUP turned on for TBEAM V1.2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -693,6 +693,9 @@ void setup()
     // without the battery temperature detection function, otherwise it will cause abnormal charging
     PMU->disableTSPinMeasure();
 #ifdef WITH_TBEAM12
+    // VBACKUP coin cell 3300mV
+    PMU->setPowerChannelVoltage(XPOWERS_VBACKUP, 3300);
+    PMU->enablePowerOutput(XPOWERS_VBACKUP);
     // RF 3300mV
     PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
     PMU->enablePowerOutput(XPOWERS_ALDO2);


### PR DESCRIPTION
The LilyGo T-Beam V1.2 has the new power manager IC AXP2101. With the build configuration WITH_TBEAM12, VBACKUP to charge the coin cell is not turned on. The coin cell will only be discharged by the GPS module but not charged by the AXP2101.
This change turns on VBACKUP to 3.3V.
<img width="1105" height="489" alt="grafik" src="https://github.com/user-attachments/assets/5cf838b7-0759-4ed0-8f20-494c10416db3" />
